### PR TITLE
Advanced Heuristics — Linear Conflict & Pattern Database (#2)

### DIFF
--- a/app/configs/cli.yml
+++ b/app/configs/cli.yml
@@ -15,11 +15,13 @@ cli:
             default: '1,2,3,4,5,6,7,8,*'
           - name_or_flags:
               - --heuristic
-            description: 'The heuristic to use: misplaced or manhattan.'
+            description: 'The heuristic to use: misplaced, manhattan, linear-conflict, or pattern-db.'
             default: 'manhattan'
             choices:
               - misplaced
               - manhattan
+              - linear-conflict
+              - pattern-db
           - name_or_flags:
               - --blank-symbol
             description: Symbol to display for the blank tile.

--- a/app/configs/error.yml
+++ b/app/configs/error.yml
@@ -13,4 +13,4 @@ errors:
     name: Invalid Heuristic
     message:
       - lang: en_US
-        text: 'Invalid heuristic: {heuristic} (must be misplaced or manhattan)'
+        text: "Unsupported heuristic: {heuristic}. Use 'misplaced', 'manhattan', 'linear-conflict', or 'pattern-db'."

--- a/app/configs/feature.yml
+++ b/app/configs/feature.yml
@@ -22,3 +22,19 @@ features:
           name: Solve with misplaced tiles
           params:
             heuristic: 'misplaced'
+    solve_linear_conflict:
+      name: 'Solve Puzzle (Linear Conflict)'
+      description: 'Solve the 8-puzzle using Manhattan + linear conflict heuristic'
+      commands:
+        - attribute_id: solve_puzzle_event
+          name: Run A* search with linear conflict heuristic
+          params:
+            heuristic: 'linear-conflict'
+    solve_pattern_db:
+      name: 'Solve Puzzle (Pattern DB)'
+      description: 'Solve the 8-puzzle using additive pattern database heuristic'
+      commands:
+        - attribute_id: solve_puzzle_event
+          name: Run A* search with pattern database heuristic
+          params:
+            heuristic: 'pattern-db'

--- a/puzzle_run.py
+++ b/puzzle_run.py
@@ -22,7 +22,7 @@ test_cases = [
 ]
 
 # Heuristics to benchmark.
-heuristics = ['misplaced', 'manhattan']
+heuristics = ['misplaced', 'manhattan', 'linear-conflict', 'pattern-db']
 
 # Run each test case with each heuristic.
 for label, start, goal in test_cases:


### PR DESCRIPTION
## Summary

Adds two advanced admissible heuristics — Manhattan + Linear Conflict and Additive Pattern Database — to the A* 8-puzzle solver per the TRD in #2.

## Changes

### PDB Infrastructure (`app/events/settings.py`)
- `ADJACENCY_3X3` constant, `_PDB_TILES_1`/`_PDB_TILES_2` pattern constants, `_PDB_CACHE` dict
- `_abstract_state()` — extracts abstract state for a tile pattern
- `_precompute_pdb()` — backward 0-1 BFS from goal (~15k entries per 4-tile pattern)
- `_get_pdb_tables()` — lazy cache for PDB tables per goal
- `pattern_db_lookup()` — additive lookup across both patterns

### New Heuristic Methods (`app/events/puzzle.py`)
- `_linear_conflict` — Manhattan + 2 per linear conflict in rows/columns
- `_pattern_db` — delegates to module-level PDB lookup
- `execute` updated: `valid_heuristics` and `heuristic_map` now include `linear-conflict` and `pattern-db`

### Config Updates
- `feature.yml` — `solve_linear_conflict`, `solve_pattern_db` features
- `cli.yml` — `linear-conflict`, `pattern-db` added to `--heuristic` choices
- `error.yml` — `INVALID_HEURISTIC` message lists all 4 heuristics

### Benchmark
- `puzzle_run.py` — runs all 4 heuristics

## Verification

All 9 acceptance criteria pass. On the hardest test case (31 moves):
- misplaced: 143,840 nodes
- manhattan: 20,291 nodes
- linear-conflict: 12,293 nodes (39% fewer than manhattan)
- pattern-db: 1,030 nodes (95% fewer than manhattan)

All heuristics produce identical optimal path lengths.

Closes #2

Co-Authored-By: Oz <oz-agent@warp.dev>