### PR TITLE
Utils — AStarSearch Utility (#11)

### DIFF
--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -4,3 +4,4 @@
 
 # ** app
 from .state import PuzzleStateParser, PuzzleStateParser as State
+from .search import AStarSearch, AStarSearch as AStar

--- a/app/utils/search.py
+++ b/app/utils/search.py
@@ -1,0 +1,168 @@
+# *** imports
+
+# ** core
+import heapq
+from typing import Callable, Dict, List, Tuple
+
+
+# *** constants
+
+# ** constant: adjacency_3x3
+ADJACENCY_3X3 = {
+    0: [1, 3], 1: [0, 2, 4], 2: [1, 5],
+    3: [0, 4, 6], 4: [1, 3, 5, 7], 5: [2, 4, 8],
+    6: [3, 7], 7: [4, 6, 8], 8: [5, 7],
+}
+
+
+# *** utils
+
+# ** util: a_star_search
+class AStarSearch:
+    '''
+    Utility for solving the 8-puzzle via the A* search algorithm.
+    Provides static methods for running A* search, generating
+    neighbor states by blank-tile swaps on a 3x3 grid, and
+    reconstructing the solution path from a parent map.
+    '''
+
+    # * method: search (static)
+    @staticmethod
+    def search(
+            start: List[int],
+            goal: List[int],
+            heuristic_fn: Callable[[List[int], List[int]], int],
+        ) -> Tuple[List[List[int]], int]:
+        '''
+        Run the A* search algorithm on the 8-puzzle.
+
+        :param start: The initial state as a flat list of 9 ints.
+        :type start: List[int]
+        :param goal: The goal state as a flat list of 9 ints.
+        :type goal: List[int]
+        :param heuristic_fn: A heuristic function accepting (state, goal) and returning an int.
+        :type heuristic_fn: Callable[[List[int], List[int]], int]
+        :return: A tuple of (solution path as list of states, nodes expanded).
+        :rtype: Tuple[List[List[int]], int]
+        '''
+
+        # Convert states to tuples for hashing.
+        start_tuple = tuple(start)
+        goal_tuple = tuple(goal)
+
+        # Initialize the open set as a priority queue: (f, tie-breaker, state).
+        counter = 0
+        open_set = [(heuristic_fn(start, goal), counter, start_tuple)]
+        heapq.heapify(open_set)
+
+        # Track the best g-score for each state.
+        g_scores = {start_tuple: 0}
+
+        # Track parent states for path reconstruction.
+        parents = {start_tuple: None}
+
+        # Track visited states.
+        closed_set = set()
+
+        # Count nodes expanded.
+        nodes_expanded = 0
+
+        # A* main loop.
+        while open_set:
+
+            # Pop the state with the lowest f-score.
+            f, _, current = heapq.heappop(open_set)
+
+            # Skip if already visited.
+            if current in closed_set:
+                continue
+
+            # Mark the current state as visited.
+            closed_set.add(current)
+            nodes_expanded += 1
+
+            # Check if we reached the goal.
+            if current == goal_tuple:
+                path = AStarSearch.reconstruct_path(parents, current)
+                return path, nodes_expanded
+
+            # Get the current g-score.
+            current_g = g_scores[current]
+
+            # Generate neighbors by swapping the blank with adjacent tiles.
+            for neighbor in AStarSearch.get_neighbors(current):
+
+                # Skip already visited neighbors.
+                if neighbor in closed_set:
+                    continue
+
+                # Calculate the tentative g-score.
+                tentative_g = current_g + 1
+
+                # Update if this path is better.
+                if neighbor not in g_scores or tentative_g < g_scores[neighbor]:
+                    g_scores[neighbor] = tentative_g
+                    h = heuristic_fn(list(neighbor), goal)
+                    f = tentative_g + h
+                    counter += 1
+                    heapq.heappush(open_set, (f, counter, neighbor))
+                    parents[neighbor] = current
+
+        # Should not reach here if solvability was checked.
+        return [start], nodes_expanded
+
+    # * method: get_neighbors (static)
+    @staticmethod
+    def get_neighbors(state: Tuple[int, ...]) -> List[Tuple[int, ...]]:
+        '''
+        Generate all valid neighbor states by swapping the blank tile
+        with an adjacent tile on the 3x3 grid.
+
+        :param state: The current state as a tuple of 9 ints.
+        :type state: Tuple[int, ...]
+        :return: A list of neighbor states.
+        :rtype: List[Tuple[int, ...]]
+        '''
+
+        # Find the position of the blank tile.
+        blank_idx = state.index(0)
+
+        # Generate neighbor states using the adjacency map.
+        neighbors = []
+        for swap_idx in ADJACENCY_3X3[blank_idx]:
+            new_state = list(state)
+            new_state[blank_idx], new_state[swap_idx] = new_state[swap_idx], new_state[blank_idx]
+            neighbors.append(tuple(new_state))
+
+        # Return the list of neighbors.
+        return neighbors
+
+    # * method: reconstruct_path (static)
+    @staticmethod
+    def reconstruct_path(
+            parents: Dict[Tuple[int, ...], Tuple[int, ...] | None],
+            current: Tuple[int, ...],
+        ) -> List[List[int]]:
+        '''
+        Reconstruct the solution path from start to goal by tracing
+        the parent map backward from the goal state.
+
+        :param parents: A mapping from each state to its predecessor.
+        :type parents: Dict[Tuple[int, ...], Tuple[int, ...] | None]
+        :param current: The goal state to trace back from.
+        :type current: Tuple[int, ...]
+        :return: The solution path as a list of states (start to goal).
+        :rtype: List[List[int]]
+        '''
+
+        # Build the path by tracing parents from goal to start.
+        path = []
+        while current is not None:
+            path.append(list(current))
+            current = parents[current]
+
+        # Reverse to get start-to-goal order.
+        path.reverse()
+
+        # Return the path.
+        return path

--- a/app/utils/tests/test_search.py
+++ b/app/utils/tests/test_search.py
@@ -1,0 +1,188 @@
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from app.utils.search import AStarSearch, ADJACENCY_3X3
+
+
+# *** constants
+
+# ** constant: goal_state
+GOAL_STATE = [1, 2, 3, 4, 5, 6, 7, 8, 0]
+
+
+# *** helpers
+
+# ** helper: misplaced_heuristic
+def misplaced_heuristic(state, goal):
+    '''
+    Trivial misplaced-tiles heuristic for testing search.
+    '''
+    return sum(
+        1 for i in range(9)
+        if state[i] != 0 and state[i] != goal[i]
+    )
+
+
+# *** tests
+
+# ** test: get_neighbors_center
+def test_get_neighbors_center() -> None:
+    '''
+    Test neighbor generation with the blank at center position (4).
+    The center has 4 adjacent positions: 1, 3, 5, 7.
+    '''
+
+    # Create a state with blank at center (position 4).
+    state = (1, 2, 3, 4, 0, 6, 7, 8, 5)
+
+    # Generate neighbors.
+    neighbors = AStarSearch.get_neighbors(state)
+
+    # Assert 4 neighbors are generated (up, down, left, right).
+    assert len(neighbors) == 4
+
+    # Assert each neighbor has the blank swapped to an adjacent position.
+    blank_positions = {n.index(0) for n in neighbors}
+    assert blank_positions == {1, 3, 5, 7}
+
+
+# ** test: get_neighbors_corner
+def test_get_neighbors_corner() -> None:
+    '''
+    Test neighbor generation with the blank at corner position (0).
+    The top-left corner has 2 adjacent positions: 1, 3.
+    '''
+
+    # Create a state with blank at top-left corner (position 0).
+    state = (0, 2, 3, 1, 5, 6, 4, 7, 8)
+
+    # Generate neighbors.
+    neighbors = AStarSearch.get_neighbors(state)
+
+    # Assert 2 neighbors are generated (right and down).
+    assert len(neighbors) == 2
+
+    # Assert the blank moved to positions 1 and 3.
+    blank_positions = {n.index(0) for n in neighbors}
+    assert blank_positions == {1, 3}
+
+
+# ** test: get_neighbors_edge
+def test_get_neighbors_edge() -> None:
+    '''
+    Test neighbor generation with the blank at an edge position (1).
+    The top-center has 3 adjacent positions: 0, 2, 4.
+    '''
+
+    # Create a state with blank at top-center (position 1).
+    state = (2, 0, 3, 1, 5, 6, 4, 7, 8)
+
+    # Generate neighbors.
+    neighbors = AStarSearch.get_neighbors(state)
+
+    # Assert 3 neighbors are generated.
+    assert len(neighbors) == 3
+
+    # Assert the blank moved to positions 0, 2, and 4.
+    blank_positions = {n.index(0) for n in neighbors}
+    assert blank_positions == {0, 2, 4}
+
+
+# ** test: reconstruct_path
+def test_reconstruct_path() -> None:
+    '''
+    Test path reconstruction from a simple 3-step parent map.
+    '''
+
+    # Build a parent map: A -> B -> C (start -> mid -> goal).
+    state_a = (1, 2, 3, 4, 5, 6, 7, 0, 8)
+    state_b = (1, 2, 3, 4, 5, 6, 0, 7, 8)
+    state_c = (1, 2, 3, 4, 5, 6, 7, 8, 0)
+    parents = {state_a: None, state_b: state_a, state_c: state_b}
+
+    # Reconstruct the path from the goal.
+    path = AStarSearch.reconstruct_path(parents, state_c)
+
+    # Assert the path is in start-to-goal order.
+    assert len(path) == 3
+    assert path[0] == list(state_a)
+    assert path[1] == list(state_b)
+    assert path[2] == list(state_c)
+
+
+# ** test: search_already_solved
+def test_search_already_solved() -> None:
+    '''
+    Test A* search when start equals goal (zero moves).
+    '''
+
+    # Run search with start == goal.
+    path, nodes_expanded = AStarSearch.search(
+        GOAL_STATE,
+        GOAL_STATE,
+        misplaced_heuristic,
+    )
+
+    # Assert the path contains only the goal state.
+    assert len(path) == 1
+    assert path[0] == GOAL_STATE
+
+    # Assert only one node was expanded (the start/goal).
+    assert nodes_expanded == 1
+
+
+# ** test: search_one_move
+def test_search_one_move() -> None:
+    '''
+    Test A* search for a puzzle one move from the goal.
+    '''
+
+    # Start: blank at position 7, tile 8 at position 8 swapped.
+    start = [1, 2, 3, 4, 5, 6, 7, 0, 8]
+
+    # Run search.
+    path, nodes_expanded = AStarSearch.search(
+        start,
+        GOAL_STATE,
+        misplaced_heuristic,
+    )
+
+    # Assert the solution is exactly 1 move.
+    assert len(path) == 2
+    assert path[0] == start
+    assert path[-1] == GOAL_STATE
+
+
+# ** test: search_known_solution
+def test_search_known_solution() -> None:
+    '''
+    Test A* search on a known puzzle configuration requiring 3 moves.
+
+    Configuration: [1, 2, 3, 0, 5, 6, 4, 7, 8]
+    Optimal path (3 moves):
+        [1,2,3,0,5,6,4,7,8] -> [1,2,3,4,5,6,0,7,8] ->
+        [1,2,3,4,5,6,7,0,8] -> [1,2,3,4,5,6,7,8,0]
+    '''
+
+    # Start: a configuration that requires 3 moves to solve.
+    start = [1, 2, 3, 0, 5, 6, 4, 7, 8]
+
+    # Run search.
+    path, nodes_expanded = AStarSearch.search(
+        start,
+        GOAL_STATE,
+        misplaced_heuristic,
+    )
+
+    # Assert the path starts at start and ends at goal.
+    assert path[0] == start
+    assert path[-1] == GOAL_STATE
+
+    # Assert the solution is optimal (3 moves).
+    assert len(path) - 1 == 3
+
+    # Assert nodes were expanded.
+    assert nodes_expanded >= 1

--- a/docs/guides/utils/search.md
+++ b/docs/guides/utils/search.md
@@ -1,0 +1,133 @@
+# AStarSearch Utility
+
+**Module:** `app/utils/search.py`  
+**Class:** `AStarSearch` (alias: `AStar`)  
+**Import:** `from app.utils import AStarSearch` or `from app.utils import AStar`
+
+## Overview
+
+`AStarSearch` provides static methods for solving the 8-puzzle using the A* search algorithm. It encapsulates the search loop, neighbor generation via blank-tile swaps on a 3×3 grid, and solution path reconstruction. The utility is a pure computational infrastructure component with no domain event dependencies — it accepts a heuristic function as a callable parameter, making it agnostic to the specific heuristic used.
+
+This module also exports the `ADJACENCY_3X3` constant, a precomputed adjacency map for the 3×3 grid used by both neighbor generation and pattern database precomputation.
+
+## The A* Algorithm
+
+A* is an informed graph search algorithm that finds the shortest path from a start state to a goal state using a combination of actual cost and heuristic estimate.
+
+### Core Concepts
+
+- **g(n):** The actual cost (number of moves) from the start to state `n`.
+- **h(n):** A heuristic estimate of the cost from state `n` to the goal. Must be admissible (never overestimates) to guarantee optimality.
+- **f(n) = g(n) + h(n):** The estimated total cost through state `n`.
+
+### Algorithm Steps
+
+1. **Initialize:** Place the start state into a priority queue (open set) ordered by `f`. Set `g(start) = 0`.
+2. **Expand:** Pop the state with the lowest `f` from the open set.
+3. **Goal check:** If the current state is the goal, reconstruct and return the path.
+4. **Generate neighbors:** For each neighbor of the current state:
+   - Skip if already in the closed set (visited).
+   - Compute `tentative_g = g(current) + 1`.
+   - If this is a new or shorter path to the neighbor, update `g`, compute `f = g + h`, and push to the open set.
+5. **Repeat** until the goal is found or the open set is empty.
+
+### Tie-Breaking
+
+When multiple states share the same `f`-score, a monotonically increasing counter is used as a tie-breaker to ensure FIFO ordering among equal-priority states. This prevents tuple comparison errors when states are not directly comparable.
+
+### Optimality Guarantee
+
+A* is optimal when the heuristic is admissible (h never overestimates) and consistent (h satisfies the triangle inequality). All four heuristics provided by the puzzle project (misplaced, Manhattan, linear conflict, pattern database) are both admissible and consistent.
+
+## ADJACENCY_3X3 Constant
+
+A precomputed dictionary mapping each position (0–8) on the 3×3 grid to its list of adjacent positions:
+
+```
+Position layout:
+  0  1  2
+  3  4  5
+  6  7  8
+
+ADJACENCY_3X3 = {
+    0: [1, 3],       1: [0, 2, 4],    2: [1, 5],
+    3: [0, 4, 6],    4: [1, 3, 5, 7], 5: [2, 4, 8],
+    6: [3, 7],       7: [4, 6, 8],    8: [5, 7],
+}
+```
+
+Corners have 2 neighbors, edges have 3, and the center has 4. This map is used by `get_neighbors` for move generation and imported by `PatternDatabase` for PDB precomputation.
+
+## Methods
+
+### `search(start, goal, heuristic_fn) -> Tuple[List[List[int]], int]`
+
+Runs the full A* search from `start` to `goal` using the provided heuristic function.
+
+**Parameters:**
+- `start: List[int]` — The initial state (flat list of 9 ints, 0 = blank).
+- `goal: List[int]` — The goal state.
+- `heuristic_fn: Callable[[List[int], List[int]], int]` — A function that takes `(state, goal)` and returns the heuristic estimate.
+
+**Returns:** A tuple of `(path, nodes_expanded)` where `path` is a list of states from start to goal (each as `List[int]`), and `nodes_expanded` is the number of states removed from the open set.
+
+**Implementation details:**
+- States are converted to tuples internally for hashability in sets and dicts.
+- Uses Python's `heapq` module for the priority queue.
+- Falls back to returning `[start]` with the expanded count if no solution is found (should not occur if solvability was checked beforehand).
+
+### `get_neighbors(state) -> List[Tuple[int, ...]]`
+
+Generates all valid neighbor states by swapping the blank tile (value 0) with each adjacent tile.
+
+**Parameters:**
+- `state: Tuple[int, ...]` — The current state as a tuple.
+
+**Returns:** A list of neighbor state tuples. The number of neighbors depends on the blank's position: 2 (corner), 3 (edge), or 4 (center).
+
+**Algorithm:**
+1. Find the blank tile's index in the state.
+2. Look up adjacent positions from `ADJACENCY_3X3`.
+3. For each adjacent position, create a copy of the state with the blank and adjacent tile swapped.
+
+### `reconstruct_path(parents, current) -> List[List[int]]`
+
+Traces the parent map backward from the goal state to the start to build the solution path.
+
+**Parameters:**
+- `parents: Dict[Tuple[int, ...], Tuple[int, ...] | None]` — A mapping from each state to its predecessor (`None` for the start).
+- `current: Tuple[int, ...]` — The goal state to trace back from.
+
+**Returns:** The solution path as a list of states in start-to-goal order (each as `List[int]`).
+
+## Usage by Domain Events
+
+The `SolvePuzzle` domain event delegates to `AStarSearch.search()` for the core search logic. The heuristic function is selected from `HeuristicCalculator` and passed as a callable:
+
+```python
+from app.utils import AStar, Heuristic
+
+# Select heuristic.
+heuristic_fn = Heuristic.manhattan
+
+# Run A* search.
+path, nodes_expanded = AStar.search(start_state, goal_state, heuristic_fn)
+```
+
+This decoupling allows the search algorithm to remain independent of heuristic implementation, and both can be tested and extended independently.
+
+## Testing
+
+Tests are located in `app/utils/tests/test_search.py` and cover:
+- Neighbor generation at center, corner, and edge positions.
+- Path reconstruction from a known parent map.
+- Search with start equal to goal (zero moves).
+- Search with a one-move puzzle.
+- Search with a known multi-move configuration (verified optimal).
+
+A trivial misplaced-tiles lambda is used as the heuristic in tests, keeping the search tests independent of the `HeuristicCalculator` utility.
+
+Run tests with:
+```bash
+pytest app/utils/tests/test_search.py -v
+```


### PR DESCRIPTION
## Summary

Ports the `AStarSearch` utility class from the `v0.x-proto` prototype to the `v0.2-release` branch, closing #11.

## Changes

- **`app/utils/search.py`** — `AStarSearch` class with `ADJACENCY_3X3` constant and 3 static methods (`search`, `get_neighbors`, `reconstruct_path`).
- **`app/utils/tests/test_search.py`** — 7 tests covering neighbor generation (center/corner/edge), path reconstruction, and search scenarios (already solved, one move, known 3-move solution).
- **`app/utils/__init__.py`** — Added `AStarSearch` / `AStar` exports.
- **`docs/guides/utils/search.md`** — Utility guide with A* algorithm synopsis, method descriptions, and usage examples.

## Test Results

All 19 utility tests pass (7 search + 12 state).

Co-Authored-By: Oz <oz-agent@warp.dev>